### PR TITLE
Update to EH1.0alpha.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ license = "MIT"
 repository = "https://github.com/nebelgrau77/lps22hb-rs"
 
 [dependencies]
-embedded-hal  = { version = "0.2" }
+embedded-hal = { version = "1.0.0-alpha.8" }

--- a/src/interface/i2c.rs
+++ b/src/interface/i2c.rs
@@ -1,21 +1,14 @@
 //! I2C Interface
 use super::Interface;
-use embedded_hal::blocking::i2c::{Write, WriteRead};
-
-/// Errors in this crate
-#[derive(Debug)]
-pub enum Error<CommE> {
-    /// Communication error
-    Comm(CommE),
-}
+use embedded_hal::i2c::blocking::I2c;
 
 /// Pressure sensor address for I2C communication
 #[allow(non_camel_case_types)]
-pub enum I2cAddress {    
+pub enum I2cAddress {
     /// SA0 pad tied to VCC
-    SA0_VCC =   0b1011101,
+    SA0_VCC = 0b1011101,
     /// SA0 pad tied to ground
-    SA0_GND =   0b1011100,   
+    SA0_GND = 0b1011100,
 }
 
 impl I2cAddress {
@@ -27,7 +20,7 @@ impl I2cAddress {
 /// This holds `I2C` and device address
 pub struct I2cInterface<I2C> {
     i2c: I2C,
-    dev_addr: u8,    
+    dev_addr: u8,
 }
 
 impl<I2C> I2cInterface<I2C> {
@@ -38,35 +31,29 @@ impl<I2C> I2cInterface<I2C> {
     pub fn init(i2c: I2C, dev_addr: I2cAddress) -> Self {
         Self {
             i2c,
-            dev_addr: dev_addr.addr(),            
+            dev_addr: dev_addr.addr(),
         }
     }
 }
 
 /// Implementation of `Interface`
-impl<I2C, CommE> Interface for I2cInterface<I2C>
+impl<I2C> Interface for I2cInterface<I2C>
 where
-    I2C: WriteRead<Error = CommE> + Write<Error = CommE>,
+    I2C: I2c,
 {
-    type Error = Error<CommE>;
+    type Error = I2C::Error;
 
     fn write(&mut self, addr: u8, value: u8) -> Result<(), Self::Error> {
-        //let sensor_addr = self.dev_addr;        
-        core::prelude::v1::Ok(
-            self.i2c
-                //.write(sensor_addr, &[addr, value])
-                .write(self.dev_addr, &[addr, value])
-                .map_err(Error::Comm)?,
-        )
+        //let sensor_addr = self.dev_addr;
+        self.i2c
+            //.write(sensor_addr, &[addr, value])
+            .write(self.dev_addr, &[addr, value])
     }
 
     fn read(&mut self, addr: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
-        //let sensor_addr = self.dev_addr;        
-        core::prelude::v1::Ok(
-            self.i2c
-                //.write_read(sensor_addr, &[addr], buffer)
-                .write_read(self.dev_addr, &[addr], buffer)
-                .map_err(Error::Comm)?,
-        )
+        //let sensor_addr = self.dev_addr;
+        self.i2c
+            //.write_read(sensor_addr, &[addr], buffer)
+            .write_read(self.dev_addr, &[addr], buffer)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,7 @@ where
     /// Clear selected bits using a bitmask
     fn clear_register_bit_flag(&mut self, address: Registers, bitmask: u8) -> Result<(), T::Error> {
         let mut reg_data = [0u8; 1];
-        self.interface.read(address.addr(), &mut reg_data)?;        
+        self.interface.read(address.addr(), &mut reg_data)?;
         let payload: u8 = reg_data[0] & !bitmask;
         self.interface.write(address.addr(), payload)?;
         Ok(())


### PR DESCRIPTION
While wanting to use this nice driver in embassy land, I noticed it's HAL version is slightly outdated. Perhaps we in this issue either update the dependency immediately (minor code changes in the driver as seen in this commit) or wait until E-H 1.0 is completely out, and update the driver then.
Thanks, and let me know what you think :)